### PR TITLE
Add menu logic and forms for Cybershop bot

### DIFF
--- a/cybershop_bot/README.md
+++ b/cybershop_bot/README.md
@@ -1,9 +1,10 @@
 # CYBERSHOP Telegram Bot
 
-Skeleton project for a Telegram bot based on **aiogram 3**.
+Telegram bot for the CYBERSHOP service built with **aiogram 3**.
 
-This repository contains the initial structure and database setup. The bot will be
-implemented later.
+The bot shows a main menu with inline buttons and collects data from users for
+service requests, trade-in, and warranty extension. All answers are stored in
+an SQLite database and logged to individual files in `logs/{user_id}`.
 
 ## Project structure
 

--- a/cybershop_bot/handlers/__init__.py
+++ b/cybershop_bot/handlers/__init__.py
@@ -1,0 +1,14 @@
+from aiogram import Dispatcher
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from utils.middleware import DBSessionMiddleware
+from .menu import router as menu_router
+from .forms import router as forms_router
+
+
+def setup(dp: Dispatcher, session_maker: async_sessionmaker) -> None:
+    middleware = DBSessionMiddleware(session_maker)
+    dp.message.middleware(middleware)
+    dp.callback_query.middleware(middleware)
+    dp.include_router(menu_router)
+    dp.include_router(forms_router)

--- a/cybershop_bot/handlers/forms.py
+++ b/cybershop_bot/handlers/forms.py
@@ -1,0 +1,215 @@
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import ServiceRequest, TradeInRequest, Feedback
+from utils.logger import log_user_action
+from keyboards.main import main_menu, manual_kb
+
+router = Router()
+
+
+class ServiceStates(StatesGroup):
+    name = State()
+    phone = State()
+    time = State()
+
+
+class TradeInStates(StatesGroup):
+    manufacturer = State()
+    model = State()
+    photo1 = State()
+    photo2 = State()
+    contact = State()
+
+
+class FeedbackStates(StatesGroup):
+    screenshot = State()
+    order_info = State()
+    contact = State()
+
+
+async def save_service(session: AsyncSession, data: dict, category: str) -> None:
+    session.add(ServiceRequest(
+        name=data['name'],
+        phone=data['phone'],
+        preferred_time=data['time'],
+        category=category,
+    ))
+    await session.commit()
+
+
+async def save_tradein(session: AsyncSession, data: dict) -> None:
+    session.add(TradeInRequest(**data))
+    await session.commit()
+
+
+async def save_feedback(session: AsyncSession, data: dict) -> None:
+    session.add(Feedback(**data))
+    await session.commit()
+
+
+@router.callback_query(F.data == 'service_form')
+async def start_service_form(call: CallbackQuery, state: FSMContext):
+    await call.message.answer('Введите ваше имя:')
+    await state.update_data(category='maintenance')
+    await state.set_state(ServiceStates.name)
+    await call.answer()
+    log_user_action(call.from_user.id, 'service_form', call.from_user.username)
+
+
+@router.callback_query(F.data == 'upgrade_form')
+async def start_upgrade_form(call: CallbackQuery, state: FSMContext):
+    await call.message.answer(
+        '🧩 Хотите ускорить ноутбук, увеличить объём памяти или устранить проблемы?\n\n'
+        'Мы проведём бесплатную диагностику и подскажем, как можно улучшить ваш ноутбук.\n\n'
+        '📌 Доступна бесплатная консультация по промокоду "UPGRADE2025".'
+    )
+    await call.message.answer('Введите ваше имя:')
+    await state.update_data(category='upgrade')
+    await state.set_state(ServiceStates.name)
+    await call.answer()
+    log_user_action(call.from_user.id, 'upgrade_form', call.from_user.username)
+
+
+@router.message(ServiceStates.name)
+async def service_name(message: Message, state: FSMContext, session: AsyncSession):
+    data = await state.get_data()
+    category = data.get('category', 'maintenance')
+    await state.update_data(name=message.text, category=category)
+    await message.answer('Телефон или Telegram:')
+    await state.set_state(ServiceStates.phone)
+    log_user_action(message.from_user.id, 'name_entered', message.from_user.username)
+
+
+@router.message(ServiceStates.phone)
+async def service_phone(message: Message, state: FSMContext):
+    await state.update_data(phone=message.text)
+    await message.answer('Удобное время для связи:')
+    await state.set_state(ServiceStates.time)
+    log_user_action(message.from_user.id, 'phone_entered', message.from_user.username)
+
+
+@router.message(ServiceStates.time)
+async def service_time(message: Message, state: FSMContext, session: AsyncSession):
+    data = await state.get_data()
+    data['time'] = message.text
+    category = data.get('category', 'maintenance')
+    await save_service(session, data, category)
+    await message.answer('✅ Ваша заявка на ТО принята! Мы свяжемся с вами в ближайшее время.', reply_markup=main_menu())
+    await state.clear()
+    log_user_action(message.from_user.id, 'service_form_complete', message.from_user.username)
+
+
+@router.callback_query(F.data == 'manual')
+async def show_manual(call: CallbackQuery):
+    text = (
+        '💡 Полезно знать!\n\n'
+        'Все ноутбуки содержат термоинтерфейс (термопасту), который со временем высыхает. Это приводит к перегреву системы, деградации чипов и в итоге — к поломке.\n\n'
+        '➤ Также внутри скапливаются пыль, волосы и грязь, которые мешают охлаждению.\n\n'
+        '🔁 Чтобы избежать проблем, проходите Техническое обслуживание (ТО) каждые 6 месяцев.'
+    )
+    await call.message.answer(text, reply_markup=manual_kb())
+    await call.answer()
+    log_user_action(call.from_user.id, 'manual', call.from_user.username)
+
+
+@router.callback_query(F.data == 'tradein')
+async def start_tradein(call: CallbackQuery, state: FSMContext):
+    text = (
+        '🔁 Хотите сдать старый ноутбук и получить скидку на новый?\n\n'
+        'Мы принимаем технику в любом состоянии. Цена выкупа — выше рыночной. Официальные партнёры Авито.\n\n'
+        '✅ Выкуп в течение 1 дня после заявки\n🎁 При сдаче техники — получите 2 подарка на выбор (мышка, сумка, подставка и др.)'
+    )
+    await call.message.answer(text)
+    await call.message.answer('Производитель:')
+    await state.set_state(TradeInStates.manufacturer)
+    await call.answer()
+    log_user_action(call.from_user.id, 'tradein', call.from_user.username)
+
+
+@router.message(TradeInStates.manufacturer)
+async def tradein_manufacturer(message: Message, state: FSMContext):
+    await state.update_data(manufacturer=message.text)
+    await message.answer('Модель:')
+    await state.set_state(TradeInStates.model)
+    log_user_action(message.from_user.id, 'manufacturer_entered', message.from_user.username)
+
+
+@router.message(TradeInStates.model)
+async def tradein_model(message: Message, state: FSMContext):
+    await state.update_data(model=message.text)
+    await message.answer('Фото 1 — внешняя крышка:')
+    await state.set_state(TradeInStates.photo1)
+    log_user_action(message.from_user.id, 'model_entered', message.from_user.username)
+
+
+@router.message(TradeInStates.photo1, F.photo)
+async def tradein_photo1(message: Message, state: FSMContext):
+    photo = message.photo[-1].file_id
+    await state.update_data(photo1=photo)
+    await message.answer('Фото 2 — наклейка с моделью:')
+    await state.set_state(TradeInStates.photo2)
+    log_user_action(message.from_user.id, 'photo1_uploaded', message.from_user.username)
+
+
+@router.message(TradeInStates.photo2, F.photo)
+async def tradein_photo2(message: Message, state: FSMContext):
+    photo = message.photo[-1].file_id
+    await state.update_data(photo2=photo)
+    await message.answer('Контакт (телефон или Telegram):')
+    await state.set_state(TradeInStates.contact)
+    log_user_action(message.from_user.id, 'photo2_uploaded', message.from_user.username)
+
+
+@router.message(TradeInStates.contact)
+async def tradein_contact(message: Message, state: FSMContext, session: AsyncSession):
+    await state.update_data(contact=message.text)
+    data = await state.get_data()
+    await save_tradein(session, data)
+    await message.answer('✅ Заявка отправлена! Менеджер свяжется с вами.', reply_markup=main_menu())
+    await state.clear()
+    log_user_action(message.from_user.id, 'tradein_complete', message.from_user.username)
+
+
+@router.callback_query(F.data == 'warranty')
+async def start_warranty(call: CallbackQuery, state: FSMContext):
+    text = (
+        '🎁 Хотите продлить гарантию?\n\n'
+        'Каждый отзыв на Авито или Яндекс увеличивает гарантию на 10 дней!\n\n'
+        '📷 Пришлите скриншот отзыва\n📦 Укажите номер заказа или модель ноутбука\n📞 И оставьте ваш контакт'
+    )
+    await call.message.answer(text)
+    await call.message.answer('Пришлите скриншот:')
+    await state.set_state(FeedbackStates.screenshot)
+    await call.answer()
+    log_user_action(call.from_user.id, 'warranty', call.from_user.username)
+
+
+@router.message(FeedbackStates.screenshot, F.photo)
+async def feedback_screenshot(message: Message, state: FSMContext):
+    photo = message.photo[-1].file_id
+    await state.update_data(screenshot=photo)
+    await message.answer('Номер заказа или модель ноутбука:')
+    await state.set_state(FeedbackStates.order_info)
+    log_user_action(message.from_user.id, 'screenshot_uploaded', message.from_user.username)
+
+
+@router.message(FeedbackStates.order_info)
+async def feedback_order(message: Message, state: FSMContext):
+    await state.update_data(order_info=message.text)
+    await message.answer('Телефон или Telegram:')
+    await state.set_state(FeedbackStates.contact)
+    log_user_action(message.from_user.id, 'order_entered', message.from_user.username)
+
+
+@router.message(FeedbackStates.contact)
+async def feedback_contact(message: Message, state: FSMContext, session: AsyncSession):
+    await state.update_data(contact=message.text)
+    data = await state.get_data()
+    await save_feedback(session, data)
+    await message.answer('✅ Гарантия будет увеличена после подтверждения отзыва.', reply_markup=main_menu())
+    await state.clear()
+    log_user_action(message.from_user.id, 'feedback_complete', message.from_user.username)

--- a/cybershop_bot/handlers/menu.py
+++ b/cybershop_bot/handlers/menu.py
@@ -1,0 +1,59 @@
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery
+from aiogram.filters import CommandStart
+from aiogram.fsm.context import FSMContext
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import User
+from utils.logger import log_user_action
+from keyboards.main import main_menu, service_menu, directions_kb
+
+router = Router()
+
+
+async def ensure_user(session: AsyncSession, message: Message) -> None:
+    stmt = await session.execute(
+        User.__table__.select().where(User.telegram_id == message.from_user.id)
+    )
+    user = stmt.fetchone()
+    if not user:
+        session.add(User(telegram_id=message.from_user.id, username=message.from_user.username))
+        await session.commit()
+
+
+@router.message(CommandStart())
+async def cmd_start(message: Message, state: FSMContext, session: AsyncSession):
+    await state.clear()
+    await ensure_user(session, message)
+    await message.answer('📋 Главное меню:\nВыберите интересующий вас раздел 👇', reply_markup=main_menu())
+    log_user_action(message.from_user.id, '/start', message.from_user.username)
+
+
+@router.callback_query(F.data == 'service')
+async def show_service(call: CallbackQuery):
+    await call.message.answer('Выберите раздел обслуживания:', reply_markup=service_menu())
+    await call.answer()
+    log_user_action(call.from_user.id, 'service', call.from_user.username)
+
+
+@router.callback_query(F.data == 'directions')
+async def show_directions(call: CallbackQuery):
+    text = '📍 Адрес: Москва, ул. Примерная, д. 5, офис 21\n🚇 Ближайшее метро: Технопарк\n🕒 Мы работаем ежедневно с 10:00 до 20:00'
+    await call.message.answer(text, reply_markup=directions_kb())
+    await call.answer()
+    log_user_action(call.from_user.id, 'directions', call.from_user.username)
+
+
+@router.callback_query(F.data == 'contact')
+async def contact_human(call: CallbackQuery):
+    await call.message.answer('Если вы не нашли нужный раздел — напишите напрямую нашему менеджеру 👇\n@cybershop_support')
+    await call.answer()
+    log_user_action(call.from_user.id, 'contact', call.from_user.username)
+
+
+@router.message()
+async def any_text(message: Message, state: FSMContext):
+    if state.get_state() is None:
+        await message.delete()
+        await message.answer('Пожалуйста, используйте кнопки')
+        log_user_action(message.from_user.id, 'text_removed', message.from_user.username)

--- a/cybershop_bot/keyboards/main.py
+++ b/cybershop_bot/keyboards/main.py
@@ -1,0 +1,37 @@
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+
+def main_menu() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text='💻 Обслуживание', callback_data='service')
+    builder.button(text='🔁 Trade-in / Выкуп', callback_data='tradein')
+    builder.button(text='🎁 Увеличить гарантию', callback_data='warranty')
+    builder.button(text='🗺 Как добраться', callback_data='directions')
+    builder.button(text='📢 Связаться с человеком', callback_data='contact')
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def service_menu() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text='🔥 Что делать, чтобы ноутбук не сгорел?', callback_data='manual')
+    builder.button(text='🛠 Записаться на ТО', callback_data='service_form')
+    builder.button(text='⚙️ Апгрейд / устранение проблем', callback_data='upgrade_form')
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def manual_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text='🛠 Записаться на ТО', callback_data='service_form')
+    builder.adjust(1)
+    return builder.as_markup()
+
+
+def directions_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.button(text='🗺 Открыть на Яндекс.Картах', url='https://yandex.ru/maps')
+    builder.button(text='📋 Скопировать адрес', callback_data='copy_address')
+    builder.adjust(1)
+    return builder.as_markup()

--- a/cybershop_bot/main.py
+++ b/cybershop_bot/main.py
@@ -4,6 +4,7 @@ from aiogram import Bot, Dispatcher
 from config import get_settings
 from db.database import get_engine, get_session_maker, init_db
 from utils.logger import logger
+from handlers import setup as setup_handlers
 
 
 async def main() -> None:
@@ -14,7 +15,8 @@ async def main() -> None:
     bot = Bot(settings.token, parse_mode='HTML')
     dp = Dispatcher()
 
-    # handlers will be registered here later
+    session_maker = get_session_maker(engine)
+    setup_handlers(dp, session_maker)
 
     logger.info('Bot started')
     await dp.start_polling(bot)

--- a/cybershop_bot/utils/middleware.py
+++ b/cybershop_bot/utils/middleware.py
@@ -1,0 +1,12 @@
+from aiogram import BaseMiddleware
+from sqlalchemy.ext.asyncio import async_sessionmaker, AsyncSession
+
+
+class DBSessionMiddleware(BaseMiddleware):
+    def __init__(self, session_maker: async_sessionmaker):
+        self.session_maker = session_maker
+
+    async def __call__(self, handler, event, data):
+        async with self.session_maker() as session:
+            data['session'] = session
+            return await handler(event, data)


### PR DESCRIPTION
## Summary
- implement inline keyboards and main menu
- add handlers for service, trade-in and warranty forms
- log user actions and store data in database
- update main file to register handlers
- update README with project details

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686d9d7c7c648329a16f3a21e99967ba