### PR TITLE
Add CYBERSHOP bot menus and forms

### DIFF
--- a/cybershop_bot/handlers/__init__.py
+++ b/cybershop_bot/handlers/__init__.py
@@ -1,5 +1,6 @@
 from aiogram import Dispatcher
 
+from .menu import router as menu_router
 from .service import router as service_router
 from .tradein import router as tradein_router
 from .feedback import router as feedback_router
@@ -7,6 +8,7 @@ from .admin_panel import router as admin_router
 
 
 def register_handlers(dp: Dispatcher) -> None:
+    dp.include_router(menu_router)
     dp.include_router(service_router)
     dp.include_router(tradein_router)
     dp.include_router(feedback_router)

--- a/cybershop_bot/handlers/feedback.py
+++ b/cybershop_bot/handlers/feedback.py
@@ -1,6 +1,5 @@
-from aiogram import Router
-from aiogram.types import Message, PhotoSize
-from aiogram.filters import Command
+from aiogram import Router, F
+from aiogram.types import Message, PhotoSize, CallbackQuery
 from aiogram.fsm.state import StatesGroup, State
 from aiogram.fsm.context import FSMContext
 
@@ -10,44 +9,27 @@ from ..db.operations import create_feedback
 from ..utils.storage import save_file
 from ..utils.notifications import send_notifications
 from ..config import Settings
+from ..keyboards.menu import to_menu_kb
 
 router = Router()
 
 
 class FeedbackForm(StatesGroup):
+    screenshot = State()
     order = State()
     contact = State()
-    screenshot = State()
 
 
-@router.message(Command("feedback"))
-async def start_feedback(message: Message, state: FSMContext) -> None:
-    await message.answer("Товар или заказ:")
-    await state.set_state(FeedbackForm.order)
-
-
-@router.message(FeedbackForm.order)
-async def process_order(message: Message, state: FSMContext) -> None:
-    await state.update_data(order=message.text)
-    await message.answer("Контакт:")
-    await state.set_state(FeedbackForm.contact)
-
-
-@router.message(FeedbackForm.contact)
-async def process_contact(message: Message, state: FSMContext) -> None:
-    await state.update_data(contact=message.text)
-    await message.answer("Прикрепите скрин")
+@router.callback_query(F.data == "feedback_form")
+async def start_feedback(callback: CallbackQuery, state: FSMContext) -> None:
+    await callback.message.delete()
+    await callback.message.answer("Прикрепите скрин отзыва")
     await state.set_state(FeedbackForm.screenshot)
+    await callback.answer()
 
 
 @router.message(FeedbackForm.screenshot)
-async def finish_feedback(
-    message: Message,
-    state: FSMContext,
-    session: AsyncSession,
-    bot,
-    settings: Settings,
-) -> None:
+async def process_screenshot(message: Message, state: FSMContext) -> None:
     if not message.photo:
         await message.answer("Нужен скрин")
         return
@@ -55,12 +37,36 @@ async def finish_feedback(
     filename = f"{message.from_user.id}_screenshot.jpg"
     downloaded = await photo.download()
     path = save_file(downloaded, filename, 'feedback')
+    await state.update_data(screenshot=path)
+    await message.delete()
+    await message.answer("Модель или номер заказа:")
+    await state.set_state(FeedbackForm.order)
+
+
+@router.message(FeedbackForm.order)
+async def process_order(message: Message, state: FSMContext) -> None:
+    await state.update_data(order=message.text)
+    await message.delete()
+    await message.answer("Телефон или Telegram:")
+    await state.set_state(FeedbackForm.contact)
+
+
+@router.message(FeedbackForm.contact)
+async def finish_feedback(
+    message: Message,
+    state: FSMContext,
+    session: AsyncSession,
+    bot,
+    settings: Settings,
+) -> None:
+    await state.update_data(contact=message.text)
+    await message.delete()
     data = await state.get_data()
     fb = await create_feedback(
         session,
         order_info=data["order"],
         contact=data["contact"],
-        screenshot=path,
+        screenshot=data["screenshot"],
     )
     text = (
         "\U0001F381 Отзыв для продления гарантии:\n\n"
@@ -71,5 +77,6 @@ async def finish_feedback(
     await send_notifications(bot, text, settings, photo_path=fb.screenshot)
     await state.clear()
     await message.answer(
-        "\u2705 Спасибо! Ваша заявка передана. Мы свяжемся с вами в течение рабочего дня."
+        "\u2705 Спасибо! Ваша заявка принята. Мы свяжемся с вами в течение дня.",
+        reply_markup=to_menu_kb(),
     )

--- a/cybershop_bot/handlers/menu.py
+++ b/cybershop_bot/handlers/menu.py
@@ -1,0 +1,122 @@
+from aiogram import Router, F
+from aiogram.types import Message, CallbackQuery
+from aiogram.filters import Command
+
+from ..keyboards.menu import (
+    start_kb,
+    main_menu_kb,
+    service_menu_kb,
+    tradein_kb,
+    feedback_kb,
+    location_kb,
+    contact_kb,
+    to_menu_kb,
+    back_service_kb,
+)
+
+router = Router()
+
+WELCOME_TEXT = (
+    "Привет! \U0001F44B\n"
+    "Я — бот CYBERSHOP. Помогу тебе быстро решить любой вопрос о ноутбуках.\n\n"
+    "Нажми кнопку ниже, чтобы начать \u2B07\uFE0F"
+)
+
+MENU_TEXT = "\U0001F4CB Главное меню:\nВыберите интересующий вас раздел \u2B07\uFE0F"
+SERVICE_INFO = (
+    "\U0001F525 Важно знать!\n\n"
+    "Все ноутбуки содержат термоинтерфейс (термопасту), который со временем теряет свойства. Это ведёт к перегреву, снижению производительности и поломке.\n"
+    "Также в систему попадают пыль, волосы, грязь — они ухудшают охлаждение.\n\n"
+    "\U0001F501 Рекомендуем проходить ТО раз в 6 месяцев.\n\n"
+    "\u2B07\uFE0F Хотите записаться?"
+)
+UPGRADE_INFO = (
+    "\u2699\uFE0F Хотите ускорить ноутбук, увеличить память или устранить проблемы?\n\n"
+    "Проведём диагностику, подберём апгрейд и бесплатно проконсультируем.\n\n"
+    "\U0001F4A1 Промокод: UPGRADE2025 — диагностика бесплатно!"
+)
+TRADEIN_INFO = (
+    "\U0001F501 Хотите обменять старый ноутбук на новый?\n\n"
+    "Мы выкупаем любую технику в течение 1 дня. Цена — выше средней по рынку.\n"
+    "\U0001F381 При сдаче техники — выберите 2 подарка (мышка, коврик, сумка и др.)\n\n"
+    "\u2B07\uFE0F Оставьте заявку:"
+)
+FEEDBACK_INFO = (
+    "\U0001F381 Хотите увеличить гарантию на 10 дней?\n\n"
+    "1. Оставьте отзыв на Яндексе или Авито\n"
+    "2. Пришлите скриншот\n"
+    "3. Укажите модель ноутбука или номер заказа\n"
+    "4. Оставьте телефон или Telegram\n\n"
+    "После проверки гарантия будет продлена."
+)
+LOCATION_TEXT = (
+    "\U0001F4CD Мы находимся по адресу:\n"
+    "Москва, ул. Примерная, д. 5, офис 21\n"
+    "\U0001F687 Метро Технопарк\n"
+    "\U0001F553 Ежедневно с 10:00 до 20:00"
+)
+CONTACT_TEXT = (
+    "\U0001F64B\u200D♂️ Не нашли нужную информацию?\n\n"
+    "Напишите нам напрямую: @cybershop_support"
+)
+
+
+@router.message(Command("start"))
+async def cmd_start(message: Message) -> None:
+    await message.answer(WELCOME_TEXT, reply_markup=start_kb())
+    await message.delete()
+
+
+@router.callback_query(F.data == "menu")
+async def show_menu(callback: CallbackQuery) -> None:
+    await callback.message.delete()
+    await callback.message.answer(MENU_TEXT, reply_markup=main_menu_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "service")
+async def service_menu(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(MENU_TEXT, reply_markup=service_menu_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "heat_info")
+async def heat_info(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(SERVICE_INFO, reply_markup=back_service_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "upgrade")
+async def upgrade_info(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(UPGRADE_INFO, reply_markup=back_service_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "tradein")
+async def tradein_info(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(TRADEIN_INFO, reply_markup=tradein_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "feedback")
+async def feedback_info(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(FEEDBACK_INFO, reply_markup=feedback_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "location")
+async def location_info(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(LOCATION_TEXT, reply_markup=location_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "contact")
+async def contact_info(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(CONTACT_TEXT, reply_markup=contact_kb())
+    await callback.answer()
+
+
+@router.callback_query(F.data == "copy_addr")
+async def copy_addr(callback: CallbackQuery) -> None:
+    await callback.answer("Адрес скопирован")
+    await callback.message.answer("Москва, ул. Примерная, д. 5, офис 21")

--- a/cybershop_bot/handlers/tradein.py
+++ b/cybershop_bot/handlers/tradein.py
@@ -1,6 +1,5 @@
-from aiogram import Router
-from aiogram.types import Message, PhotoSize
-from aiogram.filters import Command
+from aiogram import Router, F
+from aiogram.types import Message, PhotoSize, CallbackQuery
 from aiogram.fsm.state import StatesGroup, State
 from aiogram.fsm.context import FSMContext
 
@@ -10,6 +9,7 @@ from ..db.operations import create_tradein_request
 from ..utils.storage import save_file
 from ..utils.notifications import send_notifications
 from ..config import Settings
+from ..keyboards.menu import to_menu_kb
 
 router = Router()
 
@@ -17,20 +17,23 @@ router = Router()
 class TradeInForm(StatesGroup):
     brand = State()
     model = State()
-    contact = State()
     photo1 = State()
     photo2 = State()
+    contact = State()
 
 
-@router.message(Command("tradein"))
-async def start_tradein(message: Message, state: FSMContext) -> None:
-    await message.answer("Производитель:")
+@router.callback_query(F.data == "tradein_form")
+async def start_tradein(callback: CallbackQuery, state: FSMContext) -> None:
+    await callback.message.delete()
+    await callback.message.answer("Производитель:")
     await state.set_state(TradeInForm.brand)
+    await callback.answer()
 
 
 @router.message(TradeInForm.brand)
 async def process_brand(message: Message, state: FSMContext) -> None:
     await state.update_data(brand=message.text)
+    await message.delete()
     await message.answer("Модель:")
     await state.set_state(TradeInForm.model)
 
@@ -38,14 +41,8 @@ async def process_brand(message: Message, state: FSMContext) -> None:
 @router.message(TradeInForm.model)
 async def process_model(message: Message, state: FSMContext) -> None:
     await state.update_data(model=message.text)
-    await message.answer("Контакт:")
-    await state.set_state(TradeInForm.contact)
-
-
-@router.message(TradeInForm.contact)
-async def process_contact(message: Message, state: FSMContext) -> None:
-    await state.update_data(contact=message.text)
-    await message.answer("Пришлите фото 1")
+    await message.delete()
+    await message.answer("Фото 1 (внешний вид)")
     await state.set_state(TradeInForm.photo1)
 
 
@@ -55,23 +52,17 @@ async def process_photo1(message: Message, state: FSMContext) -> None:
         await message.answer("Нужна фотография")
         return
     photo: PhotoSize = message.photo[-1]
-    data = await state.get_data()
     filename = f"{message.from_user.id}_photo1.jpg"
     downloaded = await photo.download()
     path = save_file(downloaded, filename, 'tradein')
     await state.update_data(photo1=path)
-    await message.answer("Теперь фото 2")
+    await message.delete()
+    await message.answer("Фото 2 (наклейка на дне)")
     await state.set_state(TradeInForm.photo2)
 
 
 @router.message(TradeInForm.photo2)
-async def finish_tradein(
-    message: Message,
-    state: FSMContext,
-    session: AsyncSession,
-    bot,
-    settings: Settings,
-) -> None:
+async def process_photo2(message: Message, state: FSMContext) -> None:
     if not message.photo:
         await message.answer("Нужна фотография")
         return
@@ -79,13 +70,29 @@ async def finish_tradein(
     filename = f"{message.from_user.id}_photo2.jpg"
     downloaded = await photo.download()
     path2 = save_file(downloaded, filename, 'tradein')
+    await state.update_data(photo2=path2)
+    await message.delete()
+    await message.answer("Телефон или Telegram для связи:")
+    await state.set_state(TradeInForm.contact)
+
+
+@router.message(TradeInForm.contact)
+async def finish_tradein(
+    message: Message,
+    state: FSMContext,
+    session: AsyncSession,
+    bot,
+    settings: Settings,
+) -> None:
+    await state.update_data(contact=message.text)
+    await message.delete()
     data = await state.get_data()
     req = await create_tradein_request(
         session,
         manufacturer=data["brand"],
         model=data["model"],
         photo1=data["photo1"],
-        photo2=path2,
+        photo2=data["photo2"],
         contact=data["contact"],
     )
     text = (
@@ -98,5 +105,6 @@ async def finish_tradein(
     await send_notifications(bot, text, settings, photo_path=req.photo1)
     await state.clear()
     await message.answer(
-        "\u2705 Спасибо! Ваша заявка передана. Мы свяжемся с вами в течение рабочего дня."
+        "\u2705 Спасибо! Ваша заявка принята. Мы свяжемся с вами в течение дня.",
+        reply_markup=to_menu_kb(),
     )

--- a/cybershop_bot/keyboards/menu.py
+++ b/cybershop_bot/keyboards/menu.py
@@ -1,0 +1,76 @@
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def start_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="\U0001F680 \u041d\u0430\u0447\u0430\u0442\u044c", callback_data="menu")]]
+    )
+
+
+def main_menu_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="\U0001F4BB \u041e\u0431\u0441\u043b\u0443\u0436\u0438\u0432\u0430\u043d\u0438\u0435", callback_data="service"),
+                InlineKeyboardButton(text="\U0001F501 Trade-in / \u0412\u044b\u043a\u0443\u043f", callback_data="tradein"),
+            ],
+            [
+                InlineKeyboardButton(text="\U0001F381 \u0423\u0432\u0435\u043b\u0438\u0447\u0438\u0442\u044c \u0433\u0430\u0440\u0430\u043d\u0442\u0438\u044e", callback_data="feedback"),
+                InlineKeyboardButton(text="\U0001F5FA \u041a\u0430\u043a \u0434\u043e\u0431\u0440\u0430\u0442\u044c\u0441\u044f", callback_data="location"),
+            ],
+            [InlineKeyboardButton(text="\U0001F4E2 \u0421\u0432\u044f\u0437\u0430\u0442\u044c\u0441\u044f \u0441 \u0447\u0435\u043b\u043e\u0432\u0435\u043a\u043e\u043c", callback_data="contact")],
+        ]
+    )
+
+
+def service_menu_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="\U0001F525 \u0427\u0442\u043e \u0434\u0435\u043b\u0430\u0442\u044c, \u0447\u0442\u043e\u0431\u044b \u043d\u0435 \u0441\u0433\u043e\u0440\u0435\u043b?", callback_data="heat_info")],
+            [InlineKeyboardButton(text="\U0001F6E0 \u0417\u0430\u043f\u0438\u0441\u0430\u0442\u044C\u0441\u044f \u043d\u0430 \u0422\u041e", callback_data="maintenance")],
+            [InlineKeyboardButton(text="\u2699\ufe0f \u0410\u043f\u0433\u0440\u0435\u0439\u0434 / \u0443\u0441\u0442\u0440\u0430\u043d\u0435\u043d\u0438\u0435 \u043f\u0440\u043e\u0431\u043b\u0435\u043c", callback_data="upgrade")],
+            [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")],
+        ]
+    )
+
+
+def to_menu_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="\U0001F4CB \u0412\u0435\u0440\u043d\u0443\u0442\u044c\u0441\u044f \u0432 \u0433\u043b\u0430\u0432\u043d\u043e\u0435 \u043c\u0435\u043d\u044e", callback_data="menu")]]
+    )
+
+
+def back_service_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="service")]]
+    )
+
+
+def tradein_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="\U0001F4E5 \u0421\u0434\u0430\u0442\u044c \u0442\u0435\u0445\u043d\u0438\u043a\u0443", callback_data="tradein_form")],
+                         [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
+    )
+
+
+def feedback_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="\U0001F4E5 \u041e\u0442\u043f\u0440\u0430\u0432\u0438\u0442\u044c \u043e\u0442\u0437\u044b\u0432", callback_data="feedback_form")],
+                         [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
+    )
+
+
+def location_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="\U0001F5FA \u041e\u0442\u043a\u0440\u044b\u0442\u044c \u043d\u0430 \u042f\u043d\u0434\u0435\u043a\u0441.\u041a\u0430\u0440\u0442\u0430\u0445", url="https://yandex.ru/maps/?text=%D0%9C%D0%BE%D1%81%D0%BA%D0%B2%D0%B0%2C%20%D1%83%D0%BB.%20%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80%D0%BD%D0%B0%D1%8F%2C%205" )],
+            [InlineKeyboardButton(text="\U0001F4CB \u0421\u043a\u043e\u043f\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0430\u0434\u0440\u0435\u0441", callback_data="copy_addr")],
+            [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")],
+        ]
+    )
+
+
+def contact_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[[InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
+    )


### PR DESCRIPTION
## Summary
- implement user navigation with inline buttons
- add callback-based service, trade-in and feedback forms
- include main menu handler and keyboards

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686da047f1588329a2a0498531e9574b