### PR TITLE
Add user action logging middleware

### DIFF
--- a/cybershop_bot/README.md
+++ b/cybershop_bot/README.md
@@ -44,3 +44,16 @@ Install the required packages using:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Running the bot
+
+1. Copy `.env.example` to `.env` and fill in the variables:
+   - `TOKEN` — Telegram bot token
+   - `ADMIN_IDS` — comma separated list of admin Telegram IDs
+   - `MANAGER_CHAT_ID` — ID of the manager group chat
+
+2. Launch the bot using:
+
+```bash
+python -m cybershop_bot.main
+```

--- a/cybershop_bot/main.py
+++ b/cybershop_bot/main.py
@@ -8,6 +8,7 @@ from utils.logger import logger
 from handlers import register_handlers
 from utils.db_middleware import DBSessionMiddleware
 from utils.settings_middleware import SettingsMiddleware
+from utils.logging_middleware import LoggingMiddleware
 
 
 async def main() -> None:
@@ -21,8 +22,10 @@ async def main() -> None:
     session_maker = get_session_maker(engine)
     dp.message.middleware(DBSessionMiddleware(session_maker))
     dp.message.middleware(SettingsMiddleware(settings))
+    dp.message.middleware(LoggingMiddleware())
     dp.callback_query.middleware(DBSessionMiddleware(session_maker))
     dp.callback_query.middleware(SettingsMiddleware(settings))
+    dp.callback_query.middleware(LoggingMiddleware())
 
     register_handlers(dp)
 

--- a/cybershop_bot/utils/__init__.py
+++ b/cybershop_bot/utils/__init__.py
@@ -4,6 +4,7 @@ from .notifications import send_notifications
 from .storage import save_file
 from .db_middleware import DBSessionMiddleware
 from .settings_middleware import SettingsMiddleware
+from .logging_middleware import LoggingMiddleware
 from .auth import is_admin
 
 __all__ = [
@@ -14,5 +15,6 @@ __all__ = [
     "save_file",
     "DBSessionMiddleware",
     "SettingsMiddleware",
+    "LoggingMiddleware",
     "is_admin",
 ]

--- a/cybershop_bot/utils/logging_middleware.py
+++ b/cybershop_bot/utils/logging_middleware.py
@@ -1,0 +1,24 @@
+from typing import Callable, Awaitable, Any
+from aiogram import BaseMiddleware
+from aiogram.types import TelegramObject, Message, CallbackQuery
+
+from .logger import log_user_action
+
+
+class LoggingMiddleware(BaseMiddleware):
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        user = getattr(event, 'from_user', None)
+        if user:
+            if isinstance(event, Message):
+                action = event.text or event.caption or '<non-text message>'
+            elif isinstance(event, CallbackQuery):
+                action = f'callback:{event.data}'
+            else:
+                action = type(event).__name__
+            log_user_action(user.id, action, user.username)
+        return await handler(event, data)


### PR DESCRIPTION
## Summary
- add middleware to log messages and callbacks per user
- wire the middleware into bot
- document bot launch in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686da57a20a08329bb3221a683e0d4bc