### PR TITLE
Fix package imports for main module

### DIFF
--- a/cybershop_bot/main.py
+++ b/cybershop_bot/main.py
@@ -3,12 +3,12 @@ from aiogram import Bot, Dispatcher
 from aiogram.fsm.storage.memory import MemoryStorage
 
 from cybershop_bot.config import get_settings
-from db.database import get_engine, get_session_maker, init_db
-from utils.logger import logger
-from handlers import register_handlers
-from utils.db_middleware import DBSessionMiddleware
-from utils.settings_middleware import SettingsMiddleware
-from utils.logging_middleware import LoggingMiddleware
+from .db.database import get_engine, get_session_maker, init_db
+from .utils.logger import logger
+from .handlers import register_handlers
+from .utils.db_middleware import DBSessionMiddleware
+from .utils.settings_middleware import SettingsMiddleware
+from .utils.logging_middleware import LoggingMiddleware
 
 
 async def main() -> None:


### PR DESCRIPTION
## Summary
- correct imports in `cybershop_bot/main.py` so they work when executed as a package

## Testing
- `python -m py_compile cybershop_bot/main.py`
- ❌ `python -m cybershop_bot.main` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_686e4fa840c88329bc8d4063ef14092a