### PR TITLE
Add Telegram username autofill

### DIFF
--- a/cybershop_bot/handlers/tradein.py
+++ b/cybershop_bot/handlers/tradein.py
@@ -9,7 +9,7 @@ from ..db.operations import create_tradein_request
 from ..utils.storage import save_file
 from ..utils.notifications import send_notifications
 from cybershop_bot.config import Settings
-from ..keyboards.menu import to_menu_kb
+from ..keyboards.menu import to_menu_kb, contact_choice_kb
 
 router = Router()
 
@@ -72,8 +72,39 @@ async def process_photo2(message: Message, state: FSMContext) -> None:
     path2 = save_file(downloaded, filename, 'tradein')
     await state.update_data(photo2=path2)
     await message.delete()
-    await message.answer("Телефон или Telegram для связи:")
+    await message.answer(
+        "\U0001F4F1 \u041f\u043e\u0434\u0442\u0432\u0435\u0440\u0434\u0438\u0442\u0435 \u043a\u043e\u043d\u0442\u0430\u043a\u0442 \u0434\u043b\u044f \u0441\u0432\u044f\u0437\u0438:",
+        reply_markup=contact_choice_kb(),
+    )
     await state.set_state(TradeInForm.contact)
+
+
+@router.callback_query(TradeInForm.contact, F.data == "use_username")
+async def autofill_contact_tradein(
+    callback: CallbackQuery,
+    state: FSMContext,
+    session: AsyncSession,
+    bot,
+    settings: Settings,
+) -> None:
+    username = callback.from_user.username
+    if not username:
+        await callback.message.edit_text(
+            "\u2757 \u0423 \u0432\u0430\u0441 \u043d\u0435 \u0443\u0441\u0442\u0430\u043d\u043e\u0432\u043b\u0435\u043d username \u0432 Telegram. \u041f\u043e\u0436\u0430\u043b\u0443\u0439\u0441\u0442\u0430, \u0432\u0432\u0435\u0434\u0438\u0442\u0435 \u043d\u043e\u043c\u0435\u0440 \u0440\u0443\u0447\u043d\u043e.",
+            reply_markup=None,
+        )
+        await callback.answer()
+        return
+    await state.update_data(contact=f"@{username}")
+    await callback.message.delete()
+    await _finalize_tradein(callback.message, state, session, bot, settings)
+    await callback.answer()
+
+
+@router.callback_query(TradeInForm.contact, F.data == "enter_contact")
+async def ask_manual_contact_tradein(callback: CallbackQuery) -> None:
+    await callback.message.edit_text("Телефон или Telegram для связи:")
+    await callback.answer()
 
 
 @router.message(TradeInForm.contact)
@@ -86,6 +117,16 @@ async def finish_tradein(
 ) -> None:
     await state.update_data(contact=message.text)
     await message.delete()
+    await _finalize_tradein(message, state, session, bot, settings)
+
+
+async def _finalize_tradein(
+    message: Message,
+    state: FSMContext,
+    session: AsyncSession,
+    bot,
+    settings: Settings,
+) -> None:
     data = await state.get_data()
     req = await create_tradein_request(
         session,

--- a/cybershop_bot/keyboards/menu.py
+++ b/cybershop_bot/keyboards/menu.py
@@ -74,3 +74,11 @@ def contact_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[[InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
     )
+
+def contact_choice_kb() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="\U0001F464 \u0412\u0441\u0442\u0430\u0432\u0438\u0442\u044c \u043c\u043e\u0439 Telegram", callback_data="use_username")],
+            [InlineKeyboardButton(text="\u270D\uFE0F \u0412\u0432\u0435\u0441\u0442\u0438 \u0432\u0440\u0443\u0447\u043d\u0443\u044e", callback_data="enter_contact")],
+        ]
+    )


### PR DESCRIPTION
## Summary
- add new keyboard for selecting Telegram username or manual contact entry
- allow username autofill in service, trade-in and feedback forms
- finalize trade-in and feedback forms with shared helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f7dadb91c83298b446f80b4de703e