### PR TITLE
Add inline time slot selection

### DIFF
--- a/cybershop_bot/keyboards/time_slots.py
+++ b/cybershop_bot/keyboards/time_slots.py
@@ -1,0 +1,25 @@
+from datetime import datetime, timedelta
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+
+
+def generate_time_slots(start: str = "10:00", end: str = "18:30", step: int = 30) -> InlineKeyboardMarkup:
+    """Return inline keyboard with time slots from start to end with step minutes."""
+    buttons = []
+    time = datetime.strptime(start, "%H:%M")
+    end_time = datetime.strptime(end, "%H:%M")
+    row = []
+    while time <= end_time:
+        time_str = time.strftime("%H:%M")
+        row.append(
+            InlineKeyboardButton(
+                text=time_str,
+                callback_data=f"time_{time_str.replace(':', '_')}"
+            )
+        )
+        if len(row) == 3:
+            buttons.append(row)
+            row = []
+        time += timedelta(minutes=step)
+    if row:
+        buttons.append(row)
+    return InlineKeyboardMarkup(inline_keyboard=buttons)


### PR DESCRIPTION
## Summary
- generate time slot inline keyboard
- use inline keyboard in service request flow
- handle selected time via callback query

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f7ef682d0832992e4d357450237b7