### PR TITLE
Update start handler to remove initial Telegram prompt

### DIFF
--- a/cybershop_bot/handlers/menu.py
+++ b/cybershop_bot/handlers/menu.py
@@ -86,8 +86,9 @@ CONTACT_TEXT = (
 
 @router.message(Command("start"))
 async def cmd_start(message: Message) -> None:
+    if message.chat.type == "private":
+        await message.delete()
     await message.answer(WELCOME_TEXT, reply_markup=start_kb())
-    await message.delete()
 
 
 @router.callback_query(F.data == "menu")

--- a/cybershop_bot/keyboards/menu.py
+++ b/cybershop_bot/keyboards/menu.py
@@ -2,8 +2,11 @@ from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 
 def start_kb() -> InlineKeyboardMarkup:
+    """Keyboard with a single "Start" button."""
     return InlineKeyboardMarkup(
-        inline_keyboard=[[InlineKeyboardButton(text="\U0001F680 \u041d\u0430\u0447\u0430\u0442\u044c", callback_data="menu")]]
+        inline_keyboard=[
+            [InlineKeyboardButton(text="\u25B6\uFE0F \u041d\u0430\u0447\u0430\u0442\u044c", callback_data="menu")]
+        ]
     )
 
 


### PR DESCRIPTION
## Summary
- update start keyboard text and keep inline mode
- delete the initial `/start` message before responding so Telegram hint disappears

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686f9fedf7ac8329ae26d26500831f34