### PR TITLE
Improve main menu layout and contact info

### DIFF
--- a/cybershop_bot/handlers/menu.py
+++ b/cybershop_bot/handlers/menu.py
@@ -9,7 +9,7 @@ from ..keyboards.menu import (
     tradein_kb,
     feedback_kb,
     location_kb,
-    contact_manager_kb,
+    back_menu_kb,
     to_menu_kb,
     back_service_kb,
     heat_info_kb,
@@ -78,14 +78,7 @@ ADDRESS_TEXT = (
 LOCATION_TEXT = (
     "\U0001F4CD \u041c\u044b \u043d\u0430\u0445\u043e\u0434\u0438\u043c\u0441\u044f \u043f\u043e \u0430\u0434\u0440\u0435\u0441\u0443:\n" + ADDRESS_TEXT
 )
-CONTACT_TEMPLATE = (
-    "\U0001F4F2 \u0421\u0432\u044f\u0437\u044c \u0441 \u043c\u0435\u043d\u0435\u0434\u0436\u0435\u0440\u043e\u043c:\n\n"
-    "\u0412\u044b \u043c\u043e\u0436\u0435\u0442\u0435 \u043d\u0430\u043f\u0438\u0441\u0430\u0442\u044c \u043d\u0430\u043f\u0440\u044f\u043c\u0443:\n"
-    "\u2014 Telegram: @{manager}\n"
-    "\u2014 \u0422\u0435\u043b\u0435\u0444\u043e\u043d: {phone}\n"
-    "\u2014 \u0427\u0430\u0442 \u043f\u043e\u0434\u0434\u0435\u0440\u0436\u043a\u0438: @{support}\n\n"
-    "\U0001F559 \u0412\u0440\u0435\u043c\u044F \u0440\u0430\u0431\u043e\u0442\u044b: \u0435\u0436\u0435\u0434\u043d\u0435\u0432\u043d\u043e \u0441 10:00 \u0434\u043e 20:00"
-)
+CONTACT_TEXT = "Напишите нам напрямую — @{support}"
 
 
 @router.message(Command("start"))
@@ -140,14 +133,10 @@ async def location_info(callback: CallbackQuery) -> None:
 
 @router.callback_query(F.data == "contact_manager")
 async def contact_manager(callback: CallbackQuery, settings: Settings) -> None:
-    text = CONTACT_TEMPLATE.format(
-        manager=settings.manager_username,
-        phone=settings.manager_phone,
-        support=settings.support_username,
-    )
+    text = CONTACT_TEXT.format(support=settings.support_username)
     await callback.message.edit_text(
         text,
-        reply_markup=contact_manager_kb(settings.manager_username),
+        reply_markup=back_menu_kb(),
     )
     await callback.answer()
 

--- a/cybershop_bot/keyboards/menu.py
+++ b/cybershop_bot/keyboards/menu.py
@@ -13,15 +13,11 @@ def start_kb() -> InlineKeyboardMarkup:
 def main_menu_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[
-            [
-                InlineKeyboardButton(text="\U0001F4BB \u041e\u0431\u0441\u043b\u0443\u0436\u0438\u0432\u0430\u043d\u0438\u0435", callback_data="service"),
-                InlineKeyboardButton(text="\U0001F501 Trade-in / \u0412\u044b\u043a\u0443\u043f", callback_data="tradein"),
-            ],
-            [
-                InlineKeyboardButton(text="\U0001F381 \u0423\u0432\u0435\u043b\u0438\u0447\u0438\u0442\u044c \u0433\u0430\u0440\u0430\u043d\u0442\u0438\u044e", callback_data="feedback"),
-                InlineKeyboardButton(text="\U0001F5FA \u041a\u0430\u043a \u0434\u043e\u0431\u0440\u0430\u0442\u044c\u0441\u044f", callback_data="location"),
-            ],
-            [InlineKeyboardButton(text="\U0001F4E2 \u0421\u0432\u044f\u0437\u0430\u0442\u044c\u0441\u044f \u0441 \u043c\u0435\u043d\u0435\u0434\u0436\u0435\u0440\u043e\u043c", callback_data="contact_manager")],
+            [InlineKeyboardButton(text="\ud83d\udee0\ufe0f \u041e\u0431\u0441\u043b\u0443\u0436\u0438\u0432\u0430\u043d\u0438\u0435", callback_data="service")],
+            [InlineKeyboardButton(text="\u267b\ufe0f Trade-in", callback_data="tradein")],
+            [InlineKeyboardButton(text="\U0001f4c8 \u041f\u0440\u043e\u0434\u043b\u0438\u0442\u044c \u0433\u0430\u0440\u0430\u043d\u0442\u0438\u044e", callback_data="feedback")],
+            [InlineKeyboardButton(text="\U0001F4CD \u0410\u0434\u0440\u0435\u0441", callback_data="location")],
+            [InlineKeyboardButton(text="\ud83d\udcac \u0421\u0432\u044f\u0437\u0430\u0442\u044c\u0441\u044f \u0441 \u0447\u0435\u043b\u043e\u0432\u0435\u043a\u043e\u043c", callback_data="contact_manager")],
         ]
     )
 
@@ -32,7 +28,7 @@ def service_menu_kb() -> InlineKeyboardMarkup:
             [InlineKeyboardButton(text="\U0001F525 \u0427\u0442\u043e \u0434\u0435\u043b\u0430\u0442\u044c, \u0447\u0442\u043e\u0431\u044b \u043d\u0435 \u0441\u0433\u043e\u0440\u0435\u043b?", callback_data="heat_info")],
             [InlineKeyboardButton(text="\U0001F6E0 \u0417\u0430\u043f\u0438\u0441\u0430\u0442\u044C\u0441\u044f \u043d\u0430 \u0422\u041e", callback_data="maintenance")],
             [InlineKeyboardButton(text="\u2699\ufe0f \u0410\u043f\u0433\u0440\u0435\u0439\u0434 / \u0443\u0441\u0442\u0440\u0430\u043d\u0435\u043d\u0438\u0435 \u043f\u0440\u043e\u0431\u043b\u0435\u043c", callback_data="upgrade")],
-            [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")],
+            [InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="menu")],
         ]
     )
 
@@ -45,7 +41,7 @@ def to_menu_kb() -> InlineKeyboardMarkup:
 
 def back_service_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
-        inline_keyboard=[[InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="service")]]
+        inline_keyboard=[[InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="service")]]
     )
 
 
@@ -53,7 +49,7 @@ def heat_info_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[
             [InlineKeyboardButton(text="\U0001F6E0 \u0417\u0430\u043f\u0438\u0441\u0430\u0442\u044C\u0441\u044f \u043d\u0430 \u0422\u041E", callback_data="maintenance")],
-            [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="service")],
+            [InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="service")],
         ]
     )
 
@@ -61,14 +57,14 @@ def heat_info_kb() -> InlineKeyboardMarkup:
 def tradein_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[[InlineKeyboardButton(text="\U0001F4E5 \u0421\u0434\u0430\u0442\u044c \u0442\u0435\u0445\u043d\u0438\u043a\u0443", callback_data="tradein_form")],
-                         [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
+                         [InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
     )
 
 
 def feedback_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
         inline_keyboard=[[InlineKeyboardButton(text="\U0001F4E5 \u041e\u0442\u043f\u0440\u0430\u0432\u0438\u0442\u044c \u043e\u0442\u0437\u044b\u0432", callback_data="feedback_form")],
-                         [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
+                         [InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
     )
 
 
@@ -77,14 +73,14 @@ def location_kb() -> InlineKeyboardMarkup:
         inline_keyboard=[
             [InlineKeyboardButton(text="\U0001F5FA \u041e\u0442\u043a\u0440\u044b\u0442\u044c \u043d\u0430 \u042f\u043d\u0434\u0435\u043a\u0441.\u041a\u0430\u0440\u0442\u0430\u0445", url="https://yandex.ru/maps/-/CHw0646T")],
             [InlineKeyboardButton(text="\U0001F4CB \u0421\u043a\u043e\u043f\u0438\u0440\u043e\u0432\u0430\u0442\u044c \u0430\u0434\u0440\u0435\u0441", callback_data="copy_addr")],
-            [InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")],
+            [InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="menu")],
         ]
     )
 
 
 def contact_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
-        inline_keyboard=[[InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
+        inline_keyboard=[[InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
     )
 
 def contact_choice_kb() -> InlineKeyboardMarkup:
@@ -104,7 +100,7 @@ def manual_contact_kb() -> InlineKeyboardMarkup:
 
 def back_menu_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(
-        inline_keyboard=[[InlineKeyboardButton(text="\u21a9\ufe0f \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
+        inline_keyboard=[[InlineKeyboardButton(text="\ud83d\udd19 \u041d\u0430\u0437\u0430\u0434", callback_data="menu")]]
     )
 
 


### PR DESCRIPTION
## Summary
- simplify main menu button texts and place one button per row
- unify back buttons with a single icon
- show concise contact info when user taps "Связаться с человеком"

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686fa7e67c6c832991ce498aa0fe14d7